### PR TITLE
Add verbose mode to generate and extract commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,17 @@ Example call with a map drawn using OSM tiles:
 python p2g.py generate -a -2462672.600 -b 9330748.585 -c -2393838.600 -d 9421934.585 -o test2.png -t True -z 10
 ```
 
+To enable verbose output showing detailed progress information, add the `-v` or `--verbose` flag:
+
+```
+python p2g.py generate -a -2462672.600 -b 9330748.585 -c -2393838.600 -d 9421934.585 -o test2.png -t True -z 10 -v
+```
+
 Full details:
 
 ```
 usage: Paper2GIS generate [-h] -a BL_X -b BL_Y -c TR_X -d TR_Y [-e EPSG] [-r RESOLUTION] [-i INPUT] [-o OUTPUT] [-t {True,False}] [-f FADE] [-z ZOOM] [-s {True,False}] [-sa HILLSHADEALPHA] [-bf BOUNDARYFILE]
-                          [-bw BOUNDARYWIDTH] [-bc BOUNDARYCOLOUR] [-ba BOUNDARYALPHA]
+                          [-bw BOUNDARYWIDTH] [-bc BOUNDARYCOLOUR] [-ba BOUNDARYALPHA] [-v]
 
 options:
   -h, --help            show this help message and exit
@@ -129,6 +135,7 @@ options:
                         the colour of the boundary line
   -ba BOUNDARYALPHA, --boundaryalpha BOUNDARYALPHA
                         the alpha (opacity) of the boundary line
+  -v, --verbose         enable verbose output
 ```
 
 ### Extract markup from an image of a used Paper2GIS layout (`p2g.py extract`)
@@ -143,6 +150,12 @@ Example call for extraction:
 
 ```
 python p2g.py extract --reference map.png --target in.jpg -o out.shp --threshold 100 --kernel 0
+```
+
+To enable verbose output showing detailed progress information, add the `-v` or `--verbose` flag:
+
+```
+python p2g.py extract --reference map.png --target in.jpg -o out.shp --threshold 100 --kernel 0 -v
 ```
 
 Full details:
@@ -161,7 +174,7 @@ options:
 usage: Paper2GIS extract [-h] -r REFERENCE -t TARGET [-o OUTPUT] [-l LOWE_DISTANCE] [-k KERNEL] [-i THRESHOLD]
                          [-m HOMO_MATCHES] [-u UID] [-f FRAME] [-a MIN_AREA] [-x MIN_RATIO] [-b BUFFER]
                          [-cc {True,False}] [-cx {True,False}] [-cr {True,False}] [-ce {True,False}] [-ci {True,False}]
-                         [-d {True,False}]
+                         [-d {True,False}] [-v]
 
 options:
   -h, --help            show this help message and exit
@@ -200,6 +213,7 @@ options:
                         extract polygons from boundaries by extracting the inner rings
   -d {True,False}, --demo {True,False}
                         the output data file
+  -v, --verbose         enable verbose output
 ```
 
 Note that the `-cc`, `-cx`, `-cr`, `-ce` and `-ci` parameters allow you to control what type of geometry output you get (without these, the markup is converted directly to polygons).

--- a/p2g.py
+++ b/p2g.py
@@ -6,10 +6,11 @@ This is the CLI interface for Paper2GIS, it is used to generate new layouts and 
 Example usage:
     Convert a map to a Paper2GIS layout:
         `python p2g.py generate -a -2462672.600 -b 9330748.585 -c -2393838.600 -d 9421934.585`
-        `python p2g.py generate -a -393872.67 -b 7414244.26 -c -340247.96 -d 7476887.78 -o talla-hart-fells-shade.png -t True -z 11 -s True`
+        `python p2g.py generate -a -393872.67 -b 7414244.26 -c -340247.96 -d 7476887.78 -o talla-hart-fells-shade.png -t True -z 11 -s True -v`
 
     Extract Markup from an image of a Paper2GIS layout:
         `python p2g.py extract --reference out.png --target ./data/IMG_9441.jpg -o ./out/path.tif --threshold 100 --kernel 0`
+        `python p2g.py extract --reference out.png --target ./data/IMG_9441.jpg -o ./out/path.tif --threshold 100 --kernel 0 --verbose`
 """
 
 # import argparser
@@ -59,6 +60,9 @@ with catch_warnings():
     g2p_parser.add_argument('-bc','--boundarycolour', help='the colour of the boundary line', required=False, default='blue')
     g2p_parser.add_argument('-ba','--boundaryalpha', type=float, help='the alpha (opacity) of the boundary line', required=False, default=0.1)
 
+    # verbose mode
+    g2p_parser.add_argument('-v','--verbose', action='store_true', help='enable verbose output', required=False, default=False)
+
 
     ''' SET UP ARGS FOR EXTRACT '''
 
@@ -91,6 +95,9 @@ with catch_warnings():
 
     # runtime settings
     p2g_parser.add_argument('-d','--demo', choices=['True', 'False'], help='the output data file', required = False, default = 'False')
+    
+    # verbose mode
+    p2g_parser.add_argument('-v','--verbose', action='store_true', help='enable verbose output', required=False, default=False)
 
 
     ''' PARSE ARGS AND RUN '''
@@ -104,7 +111,7 @@ with catch_warnings():
         run_generate(args.bl_x, args.bl_y, args.tr_x, args.tr_y, args.epsg, 
             args.resolution, args.input, args.output, args.tiles == 'True', 
             args.fade, args.zoom, args.hillshade=='True', args.hillshadealpha, 
-            args.boundaryfile, args.boundarywidth, args.boundarycolour, args.boundaryalpha)
+            args.boundaryfile, args.boundarywidth, args.boundarycolour, args.boundaryalpha, args.verbose)
 
     # extract markup from a photograph of a map and store the result in the specified file
     elif args.command == "extract":
@@ -113,7 +120,7 @@ with catch_warnings():
             args.threshold, args.kernel, args.homo_matches, args.frame, args.min_area,
             args.min_ratio, args.buffer, args.uid, args.convex_hull=='True', 
             args.centroid=='True', args.representative_point=='True', 
-            args.exterior=='True', args.interior=='True', args.demo=='True')
+            args.exterior=='True', args.interior=='True', args.demo=='True', args.verbose)
     
     # run on test dataset, compare result to baseline and report
     elif args.command == "test":

--- a/paper2gis/paper2gis.py
+++ b/paper2gis/paper2gis.py
@@ -40,6 +40,15 @@ from cv2 import findHomography, perspectiveTransform, warpPerspective, morpholog
 	FlannBasedMatcher, threshold, imwrite, imread, cvtColor, medianBlur, SIFT_create
 
 
+# Module-level verbose flag
+_VERBOSE = False
+
+def vprint(*args, **kwargs):
+	"""Print only if verbose mode is enabled"""
+	if _VERBOSE:
+		print(*args, **kwargs)
+
+
 def extract_map(reference_img, target_img, lowe_distance, homo_matches):
 	"""
 	* Identify one image inside another, extract and perspective transform
@@ -48,9 +57,11 @@ def extract_map(reference_img, target_img, lowe_distance, homo_matches):
 	"""
 
 	# find the keypoints and descriptors with SIFT
+	vprint("Detecting keypoints with SIFT...")
 	sift = SIFT_create()
 	kp1, des1 = sift.detectAndCompute(target_img, None)
 	kp2, des2 = sift.detectAndCompute(reference_img, None)
+	vprint(f"Found {len(kp1)} keypoints in target, {len(kp2)} in reference")
 
 	# do some FLANN matching
 	flann = FlannBasedMatcher(dict(algorithm=0, trees=10), dict(checks=50))
@@ -61,6 +72,8 @@ def extract_map(reference_img, target_img, lowe_distance, homo_matches):
 	for m,n in matches:
 		if m.distance < lowe_distance * n.distance:
 			good.append(m)
+	
+	vprint(f"Matched features: {len(good)} good matches (minimum required: {homo_matches})")
 
 	# if there are not enough "good matches", report and exit
 	if len(good) < homo_matches:
@@ -71,6 +84,7 @@ def extract_map(reference_img, target_img, lowe_distance, homo_matches):
 	dst_pts = float32([ kp2[m.trainIdx].pt for m in good ]).reshape(-1,1,2)
 
 	# do some homography
+	vprint("Computing homography and warping image...")
 	M, mask = findHomography(src_pts, dst_pts, RANSAC, 10)
 	if M is None:
 		raise Exception('NO HOMOGRAPHY', "Failed to calculate Homography")
@@ -106,6 +120,7 @@ def processImage(referenceImg, participantMap, lowe_distance,
 		imwrite("./demo/4.cropped.png", cropped_map)
 
 	# threshold the image to extract markup
+	vprint("Extracting markup with thresholding and morphology...")
 	_, thresh_map = threshold(medianBlur(cropped_map, 7), thresh, 255, THRESH_BINARY_INV)
 	if demo:
 		imwrite("./demo/5.thresholded.png", thresh_map)
@@ -131,6 +146,10 @@ def writeTiff(output, opened_map, geodata):
 	* @author jonnyhuck
 	"""
 
+	vprint(f"\nWriting output to GeoTIFF:")
+	vprint(f"  - Dimensions: {opened_map.shape[1]} x {opened_map.shape[0]} pixels")
+	vprint(f"  - CRS: EPSG:{geodata[4]}")
+
 	# output dataset to raster
 	with rio_open(output, 'w', driver='GTiff', height=opened_map.shape[0],
 		width=opened_map.shape[1], count=1, dtype='uint8', crs="EPSG:" + geodata[4],
@@ -147,6 +166,8 @@ def cleanWriteShapefile(output, opened_map, geodata, buffer, min_area, min_ratio
 	* @author jonnyhuck
 	"""
 
+	vprint(f"Vectorizing and cleaning (min_area={min_area}, min_ratio={min_ratio}, buffer={buffer})...")
+
 	# make a mask of which cells we want to extract
 	mask = opened_map == 255
 
@@ -160,6 +181,9 @@ def cleanWriteShapefile(output, opened_map, geodata, buffer, min_area, min_ratio
 	geom_type = 'Point' if any([centroid, representative_point]) else 'Polygon'
 
 	# open shapefile for writing
+	feature_count = 0
+	dropped_count = {'small': 0, 'ratio': 0, 'edge': 0}
+	
 	with fio_open(output, 'w', driver="ESRI Shapefile", crs=f"EPSG:{geodata[4]}",
 		schema={'geometry': geom_type, 'properties': {'area':'float', 'uid':'int'}}) as out:
 
@@ -185,15 +209,18 @@ def cleanWriteShapefile(output, opened_map, geodata, buffer, min_area, min_ratio
 			# if too small, drop (either convex hull or regular geom)
 			the_area = geom.convex_hull.area if convex_hull else geom.area
 			if the_area < min_area:
+				dropped_count['small'] += 1
 				continue
 
 			# if wrong ratio between width & height of bounding box, drop
 			sides = [geom.bounds[2] - geom.bounds[0], geom.bounds[3] - geom.bounds[1]]
 			if min(sides) / max(sides) < min_ratio:
+				dropped_count['ratio'] += 1
 				continue
 
 			# if intersects edge, clip it
 			if geom.intersects(edge):
+				dropped_count['edge'] += 1
 				# TODO: subdivide into individual geoms
 				geom = geom.difference(edge)
 
@@ -205,16 +232,19 @@ def cleanWriteShapefile(output, opened_map, geodata, buffer, min_area, min_ratio
 			if (convex_hull):
 				out.write({'geometry': mapping(geom.convex_hull),
 					'properties': {'area': geom.convex_hull.area, 'uid': uid}})
+				feature_count += 1
 			
 			# if centroid is desired, save that
 			elif (centroid):
 				out.write({'geometry': mapping(geom.centroid),
 					'properties': {'area': 0, 'uid': uid}})
+				feature_count += 1
 
 			# if rep point is desired, save that
 			elif (representative_point):
 				out.write({'geometry': mapping(geom.representative_point()),
 					'properties': {'area': 0, 'uid': uid}})
+				feature_count += 1
 			
 			# extract exterior ring from polygon
 			elif (exterior):
@@ -227,6 +257,7 @@ def cleanWriteShapefile(output, opened_map, geodata, buffer, min_area, min_ratio
 					polygon = Polygon(g.exterior.coords)
 					out.write({'geometry': mapping(polygon),
 						'properties': {'area': geom.area, 'uid': uid}})
+					feature_count += 1
 			
 			# extract interior ring from polygon
 			elif (interior):
@@ -240,6 +271,7 @@ def cleanWriteShapefile(output, opened_map, geodata, buffer, min_area, min_ratio
 						polygon = Polygon(int_geom.coords)
 						out.write({'geometry': mapping(polygon),
 							'properties': {'area': geom.area, 'uid': uid}})
+						feature_count += 1
 
 			# TODO: have a `holes` option that gets all polygons within each 
 			# 	other polygon and adds them as holes to the constructor (or
@@ -249,16 +281,31 @@ def cleanWriteShapefile(output, opened_map, geodata, buffer, min_area, min_ratio
 			else:
 				out.write({'geometry': mapping(geom),
 					'properties': {'area': geom.area, 'uid': uid}})
+				feature_count += 1
+	
+	vprint(f"  - Features written: {feature_count}")
+	vprint(f"  - Features dropped:")
+	vprint(f"    * Too small: {dropped_count['small']}")
+	vprint(f"    * Wrong ratio: {dropped_count['ratio']}")
+	vprint(f"    * Intersected edge: {dropped_count['edge']}")
+	vprint(f"  - Successfully written to {output}")
 
 
 def run_extract(reference, target, output='out.shp', lowe_distance=0.5, thresh=100,
 	kernel=3, homo_matches=12, frame=0, min_area=1000, min_ratio=0.2, buffer=10, uid=None, convex_hull=False,
-	centroid=False, representative_point=False, exterior=False, interior=False, demo=False):
+	centroid=False, representative_point=False, exterior=False, interior=False, demo=False, verbose=False):
 	"""
 	* Main function: this runs the map extraction, resulting in a file being written
 	*  to the desired location
 	* @author jonnyhuck
 	"""
+
+	# Set module-level verbose flag
+	global _VERBOSE
+	_VERBOSE = verbose
+	
+	vprint(f"\nExtracting markup: {target} -> {output}")
+	vprint(f"Parameters: threshold={thresh}, kernel={kernel}, lowe_distance={lowe_distance}, min_matches={homo_matches}")
 
 	# make sure there are not any conflicting output options specified
 	if sum([convex_hull, centroid, representative_point, exterior, interior]) > 1:
@@ -298,8 +345,9 @@ def run_extract(reference, target, output='out.shp', lowe_distance=0.5, thresh=1
 
 	# catch HEIC/heif input file
 	if Path(target).suffix.lower() in {".heic", ".heif"}:
+		vprint("Converting HEIC/HEIF format...")
 		if demo:
-			print("converting HEIC...")
+			print("Converting HEIC/HEIF format...")
 		
 		# register HEIF opener with Pillow and open the file
 		pillow_heif.register_heif_opener()
@@ -315,6 +363,7 @@ def run_extract(reference, target, output='out.shp', lowe_distance=0.5, thresh=1
 	# read in participant map and greyscale
 	participant_map = cvtColor(ref_np, COLOR_BGR2GRAY)
 	if frame > 0:
+		vprint(f"Adding frame (multiplier: {frame})")
 		# make a white background
 		h, w = participant_map.shape
 		
@@ -336,8 +385,9 @@ def run_extract(reference, target, output='out.shp', lowe_distance=0.5, thresh=1
 	# get metadata from QR code
 	try:
 		geodata = decode(reference_img, symbols=[ZBarSymbol.QRCODE])[0].data.decode("utf-8").split(",")
+		vprint(f"Map CRS: EPSG:{geodata[4]}, UUID: {geodata[-1]}")
 		if demo:
-			print('QR_DATA=', geodata)
+			print(f"Map CRS: EPSG:{geodata[4]}, UUID: {geodata[-1]}")
 	except IndexError:
 		raise Exception('NOT A PAPER2GIS MAP', "Reference image is not a Paper2GIS map")
 
@@ -350,7 +400,7 @@ def run_extract(reference, target, output='out.shp', lowe_distance=0.5, thresh=1
 		# print("WARNING - can't read QR code in target image")
 		pass	# never seems to manage to read it!
 
-	# run the imageb processing to get binary result array
+	# run the image processing to get binary result array
 	opened_map = processImage(reference_img, participant_map, lowe_distance,
 		homo_matches, geodata, thresh, kernel, demo)
 
@@ -363,3 +413,5 @@ def run_extract(reference, target, output='out.shp', lowe_distance=0.5, thresh=1
 	elif output[-4:] == ".shp":
 		cleanWriteShapefile(output, opened_map, geodata, buffer, min_area, min_ratio, 
 		      convex_hull, centroid, representative_point, exterior, interior, uid)
+	
+	vprint("Extraction complete!")

--- a/paper2gis/paper2gis.py
+++ b/paper2gis/paper2gis.py
@@ -285,9 +285,9 @@ def cleanWriteShapefile(output, opened_map, geodata, buffer, min_area, min_ratio
 	
 	vprint(f"  - Features written: {feature_count}")
 	vprint(f"  - Features dropped:")
-	vprint(f"    * Too small: {dropped_count['small']}")
-	vprint(f"    * Wrong ratio: {dropped_count['ratio']}")
+	vprint(f"    * Area too small: {dropped_count['small']}")
 	vprint(f"    * Intersected edge: {dropped_count['edge']}")
+	vprint(f"    * Aspect ratio too small: {dropped_count['ratio']}")
 	vprint(f"  - Successfully written to {output}")
 
 
@@ -346,7 +346,7 @@ def run_extract(reference, target, output='out.shp', lowe_distance=0.5, thresh=1
 	# catch HEIC/heif input file
 	if Path(target).suffix.lower() in {".heic", ".heif"}:
 		vprint("Converting HEIC/HEIF format...")
-		if demo:
+		if demo and not _VERBOSE:
 			print("Converting HEIC/HEIF format...")
 		
 		# register HEIF opener with Pillow and open the file
@@ -386,7 +386,7 @@ def run_extract(reference, target, output='out.shp', lowe_distance=0.5, thresh=1
 	try:
 		geodata = decode(reference_img, symbols=[ZBarSymbol.QRCODE])[0].data.decode("utf-8").split(",")
 		vprint(f"Map CRS: EPSG:{geodata[4]}, UUID: {geodata[-1]}")
-		if demo:
+		if demo and not _VERBOSE:
 			print(f"Map CRS: EPSG:{geodata[4]}, UUID: {geodata[-1]}")
 	except IndexError:
 		raise Exception('NOT A PAPER2GIS MAP', "Reference image is not a Paper2GIS map")


### PR DESCRIPTION
## Summary
Adds `-v`/`--verbose` flag to both `generate` and `extract` commands, providing detailed progress information during execution.

 Addresses: https://github.com/jonnyhuck/Paper2GIS/issues/4 - (1)

## Changes
- Added `--verbose` / `-v` flag to CLI argument parsers
- Implemented module-level `vprint()` helper function for clean verbose output
- Added progress logging for key operations:
  - **Extract**: keypoint detection, feature matching, vectorization stats
  - **Generate**: tile download, UUID generation, layout composition
- Updated README.md with verbose mode examples and documentation
- Fixed potential duplicate prints when both demo and verbose modes are active

## Example Output
**Extract mode:**
```
$ python p2g.py extract -r ./out.png -t ./photo.jpg -o ./result.shp -v
```

```
Extracting markup: ./photo.jpg -> ./result.shp
Parameters: threshold=100, kernel=3, lowe_distance=0.5, min_matches=12
Map CRS: EPSG:3857, UUID: 56ddd2de
Detecting keypoints with SIFT...
Found 2661 keypoints in target, 1895 in reference
Matched features: 656 good matches (minimum required: 12)
Computing homography and warping image...
Extracting markup with thresholding and morphology...
Vectorizing and cleaning (min_area=1000, min_ratio=0.2, buffer=10)...
  - Features written: 23
  - Features dropped:
    * Area too small: 4
    * Intersected edge: 10
    * Aspect ratio too small: 7
  - Successfully written to ./result.shp
Extraction complete!
```

## Technical Notes
- Uses module-level `_VERBOSE` flag to avoid parameter passing
- Maintains backward compatibility (verbose off by default)
- Clean separation from existing demo mode